### PR TITLE
Fix TypeError on missing fps metadata; run CI on pull requests

### DIFF
--- a/.github/workflows/python_package_testing.yaml
+++ b/.github/workflows/python_package_testing.yaml
@@ -1,6 +1,9 @@
 name: Testing
 
-on: [push]
+on:
+  push:
+    branches: [master]
+  pull_request:
 
 jobs:
   build:

--- a/pyidi/video_reader.py
+++ b/pyidi/video_reader.py
@@ -492,7 +492,9 @@ class VideoReader:
             self.image_width = image_prop.shape[2]
             self.image_height = image_prop.shape[1]
             if not getattr(self, "fps", False):
-                self.configure(fps=image_meta.get("fps", None))
+                fps = image_meta.get("fps")
+                if fps:  # Not all multi-image files carry the fps metadata
+                    self.configure(fps=fps)
 
     def _initialise_video_files(self, input_file):
         """Initialise reader state for video containers handled by ``pyav``.


### PR DESCRIPTION
Two follow-ups to #62.

### 1. `TypeError` when a multi-image file has no fps metadata

`_initalise_image_files` passed the result of `image_meta.get("fps", None)` straight into `configure`:

```python
if not getattr(self, "fps", False):
    self.configure(fps=image_meta.get("fps", None))
```

`configure` gates on `"fps" in kwargs` and then does `float(kwargs["fps"])`, so a missing fps key becomes `float(None)` — a `TypeError` raised during `VideoReader` construction, for every multi-image file (e.g. a multi-page TIFF) whose metadata does not report a frame rate. The `, None)` default suggests the missing case was anticipated; it just was not guarded. Now `configure` is only called when an fps was actually reported.

Not covered by the current test data: the PNG sequence takes the `n_images is None` branch, and the gif does report fps. Adding a fixture without fps metadata would be worth doing separately.

### 2. Pull requests never ran CI

`python_package_testing.yaml` triggered on `push` only, so a PR from a fork produced no checks at all — #62 was reviewed and merged with nothing green to look at. This adds the `pull_request` trigger and scopes the push trigger to `master`, so in-repo branches do not run the 3-version matrix twice on every push.

Note that this PR is itself the first one that should show checks.

### Still open

The root cause behind the #62 test bug — `VideoReader.configure(**kwargs)` silently ignoring unknown keywords, which is how `use_channel=` sat in the tests testing nothing — is deliberately left out of this PR. Per @itomac's [comment](https://github.com/ladisk/pyidi/pull/62#issuecomment-5241371954), worth handling separately; an explicit keyword signature (as `_dic.py` and the other methods already use) would raise `TypeError` for free, which catches more than a warning does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)