### PR TITLE
Fix ArUco detection under OpenCV 5

### DIFF
--- a/pyidi/fiducial.py
+++ b/pyidi/fiducial.py
@@ -133,7 +133,8 @@ class Fiducial:
         # Try detecting markers with each dictionary
         for name, aruco_id in ARUCO_DICT.items():
             dictionary = cv2.aruco.getPredefinedDictionary(aruco_id)
-            corners, _, _ = cv2.aruco.detectMarkers(frame, dictionary, parameters=parameters)
+            detector = cv2.aruco.ArucoDetector(dictionary, parameters)
+            corners, _, _ = detector.detectMarkers(frame)
             
             if corners:
                 return name
@@ -175,9 +176,10 @@ class Fiducial:
 
             dictionary = cv2.aruco.getPredefinedDictionary(getattr(cv2.aruco, fiducial_dictionary))
             parameters = cv2.aruco.DetectorParameters()
+            detector = cv2.aruco.ArucoDetector(dictionary, parameters)
 
             for i, frame in tqdm(enumerate(video), total=len(video), dynamic_ncols=True, desc="Fiducial Markers Detection"):
-                corners, ids, _ = cv2.aruco.detectMarkers(frame, dictionary, parameters=parameters)
+                corners, ids, _ = detector.detectMarkers(frame)
 
                 if ids is not None:
                     marker_info = []


### PR DESCRIPTION
`master` has been red since 24 July; the two `tests/test_fiducial.py` failures are not caused by any recent code change.

```
AttributeError: module 'cv2.aruco' has no attribute 'detectMarkers'
pyidi/fiducial.py:136
FAILED tests/test_fiducial.py::test_compensation
FAILED tests/test_fiducial.py::test_revert_frames_shape
2 failed, 20 passed
```

`pyproject.toml` pins nothing for `opencv-contrib-python`, so CI now installs **5.0.0.93**. OpenCV 5.0 removed the free `cv2.aruco.detectMarkers` function that had been deprecated since the `ArucoDetector` class arrived in 4.7. Verified locally against 5.0.0.93: `hasattr(cv2.aruco, "detectMarkers")` is `False`, `cv2.aruco.ArucoDetector` is present and works.

Both call sites now build an `ArucoDetector` from the dictionary and parameters and call its method. In `detect_markers` the detector is constructed once outside the per-frame loop rather than per frame. `ArucoDetector` exists from 4.7 onward, so this does not raise the minimum OpenCV version for anyone still on 4.x.

Not addressed here: the failure only surfaced now because nothing was watching `master`'s runs. #63 makes pull requests report checks, which is the other half of this.